### PR TITLE
`BentoGetChild()` comparison check fix

### DIFF
--- a/scripts/BentoGetChild/BentoGetChild.gml
+++ b/scripts/BentoGetChild/BentoGetChild.gml
@@ -12,7 +12,7 @@ function BentoGetChild(_index, _parent = self)
     if ((_index < 0) || (not BentoExists(_parent))) return undefined;
     
     var _array = _parent.BENTO_VARS.__childArray;
-    if (array_length(_array) >= _index) return undefined;
+    if (_index >= array_length(_array)) return undefined;
     
     return _array[_index].__attachedElement;
 }


### PR DESCRIPTION
`BentoGetChild()` would never return a child, due to the comparison check being inverted. Currently it is compared as the length being greater than or equal to the index, which should be the other way around. 